### PR TITLE
Add check for log dir before trying to create it

### DIFF
--- a/src/Environment/System/Helpers/ApacheHelper.php
+++ b/src/Environment/System/Helpers/ApacheHelper.php
@@ -129,7 +129,7 @@ class ApacheHelper {
 
         $logPath = $this->logPath . $hostname;
 
-        if (!mkdir($logPath, 0755, true)) {
+        if (!file_exists($logPath) && !mkdir($logPath, 0755, true)) {
             throw new \RuntimeException('Could not create apache log dir ' . $logPath);
         }
 


### PR DESCRIPTION
Resolves an issue where a RunTimeException is thrown when an apache log dir already exists

```
>>>>>>>>>> STARTING DEV ENVIRONMENT...
>>> Adding a new configuration for `gm-be.dev.com` inside `/usr/local/etc/httpd/extra/httpd-vhosts.conf`.
PHP Warning:  mkdir(): File exists in /Users/garethmidwood/.cdev/plugins/vendor/cdev/environment-local/src/Environment/System/Helpers/ApacheHelper.php on line 132
Warning: mkdir(): File exists in /Users/garethmidwood/.cdev/plugins/vendor/cdev/environment-local/src/Environment/System/Helpers/ApacheHelper.php on line 132
In ApacheHelper.php line 133:
  Could not create apache log dir /tmp/cdev-local/logs/gm-be.dev.com
```